### PR TITLE
Fix `Mutex_m#initialize` when the super's initialize has kwargs

### DIFF
--- a/lib/mutex_m.rb
+++ b/lib/mutex_m.rb
@@ -109,8 +109,17 @@ module Mutex_m
     @_mutex = Thread::Mutex.new
   end
 
-  def initialize(*args) # :nodoc:
-    mu_initialize
-    super
+  if RUBY_VERSION < '2.7'
+    def initialize(*args) # :nodoc:
+      mu_initialize
+      super
+    end
+  else
+    eval <<~RUBY, binding, __FILE__, __LINE__ + 1
+      def initialize(...) # :nodoc:
+        mu_initialize
+        super
+      end
+    RUBY
   end
 end

--- a/lib/mutex_m.rb
+++ b/lib/mutex_m.rb
@@ -109,17 +109,9 @@ module Mutex_m
     @_mutex = Thread::Mutex.new
   end
 
-  if RUBY_VERSION < '2.7'
-    def initialize(*args) # :nodoc:
-      mu_initialize
-      super
-    end
-  else
-    eval <<~RUBY, binding, __FILE__, __LINE__ + 1
-      def initialize(...) # :nodoc:
-        mu_initialize
-        super
-      end
-    RUBY
+  def initialize(*args) # :nodoc:
+    mu_initialize
+    super
   end
+  ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 end

--- a/test/test_mutex_m.rb
+++ b/test/test_mutex_m.rb
@@ -23,4 +23,36 @@ class TestMutexM < Test::Unit::TestCase
     c.signal
     assert_equal "abc", t.value
   end
+
+  class KeywordInitializeParent
+    def initialize(x:)
+    end
+  end
+
+  class KeywordInitializeChild < KeywordInitializeParent
+    include Mutex_m
+    def initialize
+      super(x: 1)
+    end
+  end
+
+  def test_initialize_with_keyword_arg
+    assert KeywordInitializeChild.new
+  end
+
+  class NoArgInitializeParent
+    def initialize
+    end
+  end
+
+  class NoArgInitializeChild < NoArgInitializeParent
+    include Mutex_m
+    def initialize
+      super()
+    end
+  end
+
+  def test_initialize_no_args
+    assert NoArgInitializeChild.new
+  end
 end


### PR DESCRIPTION
This pull request fixes an error of Ruby 3 keyword arguments for `Mutex_m#initialize`.


See https://github.com/ruby/ruby/pull/3310
