### PR TITLE
Make Mutex_m work with Module#prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ obj.extend Mutex_m
 ```
 
 Or mixin Mutex_m into your module to your class inherit Mutex instance methods.
+You should probably use `prepend` to mixin (if you use `include`, you need to
+make sure that you call `super` inside `initialize`).
 
 ```ruby
 class Foo
-  include Mutex_m
+  prepend Mutex_m
   # ...
 end
 

--- a/lib/mutex_m.rb
+++ b/lib/mutex_m.rb
@@ -52,6 +52,11 @@ module Mutex_m
     }
   end
 
+  def Mutex_m.prepend_features(cl) # :nodoc:
+    super
+    define_aliases(cl) unless cl.instance_of?(Module)
+  end
+
   def Mutex_m.append_features(cl) # :nodoc:
     super
     define_aliases(cl) unless cl.instance_of?(Module)

--- a/test/test_mutex_m.rb
+++ b/test/test_mutex_m.rb
@@ -55,4 +55,47 @@ class TestMutexM < Test::Unit::TestCase
   def test_initialize_no_args
     assert NoArgInitializeChild.new
   end
+
+  class PositionalArgInitializeParent
+    attr_reader :x
+
+    def initialize(x)
+      @x = x
+    end
+  end
+
+  def test_include
+    c = PositionalArgInitializeParent.dup
+    c.class_eval do
+      alias initialize initialize
+      def initialize(x)
+        @x = x
+        super()
+      end
+      include Mutex_m
+    end
+    o = c.new(1)
+    assert_equal(1, o.synchronize{o.x})
+  end
+
+  def test_prepend
+    c = PositionalArgInitializeParent.dup
+    c.prepend Mutex_m
+    o = c.new(1)
+    assert_equal(1, o.synchronize{o.x})
+  end
+
+  def test_include_sub
+    c = Class.new(PositionalArgInitializeParent)
+    c.include Mutex_m
+    o = c.new(1)
+    assert_equal(1, o.synchronize{o.x})
+  end
+
+  def test_prepend_sub
+    c = Class.new(PositionalArgInitializeParent)
+    c.prepend Mutex_m
+    o = c.new(1)
+    assert_equal(1, o.synchronize{o.x})
+  end
 end


### PR DESCRIPTION
Recommend prepend over include in README, since include has issues
unless initialize calls super. However, add documentation on how
to get it to work with include.

Fixes #1