### PR TITLE
Make VERSION shareable

### DIFF
--- a/lib/mutex_m.rb
+++ b/lib/mutex_m.rb
@@ -41,6 +41,7 @@
 module Mutex_m
 
   VERSION = "0.1.1"
+  Ractor.make_shareable(VERSION) if defined?(Ractor)
 
   def Mutex_m.define_aliases(cl) # :nodoc:
     cl.module_eval %q{


### PR DESCRIPTION
By making VERSION shareable, it can be accessed within Ractors.