### PR TITLE
Bundle RBS files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rbs", "~> 3.4"

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "rbs", "~> 3.4"
+gem "rdoc"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rbs", "~> 3.4"
-gem "rdoc"
+if RUBY_VERSION >= "3.0.0"
+  gem "rbs", "~> 3.4"
+  gem "rdoc"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,13 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task :default => :test
+
+namespace :rbs do
+  desc "Update embedded RDoc comments in RBS files"
+  task :rdoc do
+    sh "rm -rf tmp/rbs/ri"
+    sh "mkdir -p tmp/rbs"
+    sh "rdoc lib --format=ri -o tmp/rbs/ri"
+    sh "rbs annotate --dir=tmp/rbs/ri --no-system --no-filename sig"
+  end
+end

--- a/sig/mutex_m.rbs
+++ b/sig/mutex_m.rbs
@@ -1,0 +1,99 @@
+# # mutex_m.rb
+#
+# When 'mutex_m' is required, any object that extends or includes Mutex_m will
+# be treated like a Mutex.
+#
+# Start by requiring the standard library Mutex_m:
+#
+#     require "mutex_m.rb"
+#
+# From here you can extend an object with Mutex instance methods:
+#
+#     obj = Object.new
+#     obj.extend Mutex_m
+#
+# Or mixin Mutex_m into your module to your class inherit Mutex instance methods
+# --- remember to call super() in your class initialize method.
+#
+#     class Foo
+#       include Mutex_m
+#       def initialize
+#         # ...
+#         super()
+#       end
+#       # ...
+#     end
+#     obj = Foo.new
+#     # this obj can be handled like Mutex
+#
+module Mutex_m
+  def self.append_features: (Module cl) -> untyped
+
+  def self.define_aliases: (Module cl) -> untyped
+
+  def self.extend_object: (Object obj) -> untyped
+
+  public
+
+  def mu_extended: () -> untyped
+
+  # <!--
+  #   - mu_lock()
+  # -->
+  # See Thread::Mutex#lock
+  #
+  def mu_lock: () -> Thread::Mutex
+
+  # <!--
+  #   - mu_locked?()
+  # -->
+  # See Thread::Mutex#locked?
+  #
+  def mu_locked?: () -> bool
+
+  # <!--
+  #   - mu_synchronize(&block)
+  # -->
+  # See Thread::Mutex#synchronize
+  #
+  def mu_synchronize: [T] () { () -> T } -> T
+
+  # <!--
+  #   - mu_try_lock()
+  # -->
+  # See Thread::Mutex#try_lock
+  #
+  def mu_try_lock: () -> bool
+
+  # <!--
+  #   - mu_unlock()
+  # -->
+  # See Thread::Mutex#unlock
+  #
+  def mu_unlock: () -> Thread::Mutex
+
+  # <!--
+  #   - sleep(timeout = nil)
+  # -->
+  # See Thread::Mutex#sleep
+  #
+  def sleep: (?Numeric timeout) -> Integer?
+
+  alias locked? mu_locked?
+
+  alias lock mu_lock
+
+  alias unlock mu_unlock
+
+  alias try_lock mu_try_lock
+
+  alias synchronize mu_synchronize
+
+  private
+
+  def initialize: (*untyped args) -> untyped
+
+  def mu_initialize: () -> untyped
+end
+
+Mutex_m::VERSION: String

--- a/sig/mutex_m.rbs
+++ b/sig/mutex_m.rbs
@@ -5,7 +5,7 @@
 #
 # Start by requiring the standard library Mutex_m:
 #
-#     require "mutex_m.rb"
+#     require "mutex_m"
 #
 # From here you can extend an object with Mutex instance methods:
 #

--- a/test/test_rbs_types.rb
+++ b/test/test_rbs_types.rb
@@ -1,6 +1,10 @@
 require 'test/unit'
 require 'mutex_m'
-require 'rbs/unit_test'
+begin
+  require 'rbs/unit_test'
+rescue LoadError
+  return
+end
 
 module RBSTypeTest
   class Mutex_mInstanceTest < Test::Unit::TestCase

--- a/test/test_rbs_types.rb
+++ b/test/test_rbs_types.rb
@@ -1,0 +1,58 @@
+require 'test/unit'
+require 'mutex_m'
+require 'rbs/unit_test'
+
+module RBSTypeTest
+  class Mutex_mInstanceTest < Test::Unit::TestCase
+    include RBS::UnitTest::TypeAssertions
+
+    library 'mutex_m'
+    testing "::Mutex_m"
+
+    def mu
+      Object.new.tap do |o|
+        o.extend Mutex_m
+      end
+    end
+
+    def test_mu_lock
+      assert_send_type "() -> Thread::Mutex",
+                       mu, :mu_lock
+    end
+
+    def test_mu_locked?
+      mu = mu()
+      assert_send_type "() -> false",
+                       mu, :mu_locked?
+      mu.lock
+      assert_send_type "() -> true",
+                       mu, :mu_locked?
+    end
+
+    def test_mu_synchronize
+      assert_send_type "() { () -> String } -> String",
+                       mu, :mu_synchronize do 'foo' end
+    end
+
+    def test_mu_try_lock
+      assert_send_type "() -> bool",
+                       mu, :mu_try_lock
+    end
+
+    def test_mu_unlock
+      mu = mu()
+      mu.lock
+      assert_send_type "() -> Thread::Mutex",
+                       mu, :mu_unlock
+    end
+
+    def test_sleep
+      mu = mu()
+      mu.lock
+      assert_send_type "(Integer) -> Integer?",
+                       mu, :sleep, 0
+      assert_send_type "(Float) -> Integer?",
+                       mu, :sleep, 0.1
+    end
+  end
+end


### PR DESCRIPTION
Move RBS type definition from `ruby/rbs` to the gem repository.

It also adds `rbs:rdoc` rake task to update embedded RDoc comments.

Note that we may want to release a new version with bundled RBS files after rbs-3.5 is out, because prior versions have type definitions of mutex_m inside them.