### PR TITLE
mutex_m.rb: Drop a superfluous .rb suffix in docs

### DIFF
--- a/lib/mutex_m.rb
+++ b/lib/mutex_m.rb
@@ -17,7 +17,7 @@
 #
 # Start by requiring the standard library Mutex_m:
 #
-#   require "mutex_m.rb"
+#   require "mutex_m"
 #
 # From here you can extend an object with Mutex instance methods:
 #


### PR DESCRIPTION
Documentation change, seen via #15. 