### PR TITLE
Publish RBS

### DIFF
--- a/mutex_m.gemspec
+++ b/mutex_m.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.licenses = %w[Ruby BSD-2-Clause]
 
-  spec.files = %w[LICENSE.txt README.md lib/mutex_m.rb]
+  spec.files = %w[LICENSE.txt README.md lib/mutex_m.rb sig/mutex_m.rbs]
   spec.required_ruby_version = ">= 2.5"
 end


### PR DESCRIPTION
Same as https://github.com/ruby/prime/pull/28 .

## Current

Currently, when a user does a rbs collection install, mutex_m uses the type definition of [ruby/rbs](https://github.com/ruby/rbs/tree/b3afd778067de52784f0df38f7f834d22dc0bf2c/stdlib/mutex_m/0).
mutex_m has a history of copying the sig directory from ruby/rbs (https://github.com/ruby/mutex_m/pull/15), but does not include the sig directory in the gem package.
rbs searches for the type definition of mutex_m in the order of gem package -> rbs repository -> gem_rbs_collection, and uses the type definition of rbs repository found.

## Change

Include the files in the sig directory in the gem package to give preference to type definitions in this repository.

## Notice

The scenarios where the signatures from this repository reach users are quite limited.
This is because the issue lies on the ruby/rbs side.

To ensure users can access the repository's signatures, two issues need to be resolved.
This PR solves one of them. I also plan to fix the issue with ruby/rbs.